### PR TITLE
add fusion-blossom

### DIFF
--- a/src/PyQDecoders.jl
+++ b/src/PyQDecoders.jl
@@ -7,6 +7,7 @@ const np = PythonCall.pynew()
 const pm = PythonCall.pynew()
 const ldpc = PythonCall.pynew()
 const ldpccodes = PythonCall.pynew()
+const fb = PythonCall.pynew()
 
 function __init__()
     PythonCall.pycopy!(sp, PythonCall.pyimport("scipy"))
@@ -15,6 +16,8 @@ function __init__()
     PythonCall.pycopy!(pm, PythonCall.pyimport("pymatching"))
     PythonCall.pycopy!(ldpc, PythonCall.pyimport("ldpc"))
     PythonCall.pycopy!(ldpccodes, PythonCall.pyimport("ldpc.codes"))
+    PythonCall.pycopy!(fb, PythonCall.pyimport("fusion_blossom"))
+
 end
 
 end # module


### PR DESCRIPTION
This PR aims to introduce fusion blossom python call so that fusion blossom decoder extension namely `FusionBlossomInterface` can be made in `QuantumClifford.jl` following the guidance in https://github.com/QuantumSavory/QuantumClifford.jl/issues/14#issue-916346774!

The following now works as a quick test :)

```julia
using PythonCall
const fb = PythonCall.pyimport("fusion_blossom")
code = fb.CodeCapacityPlanarCode(d=11, p=0.05, max_half_weight=500)
syndrome = code.generate_random_errors()
initializer = code.get_initializer()
solver = fb.SolverSerial(initializer)
solver.solve(syndrome)
subgraph = solver.subgraph()
println("Minimum Weight Parity Subgraph (MWPS): ", subgraph)
```
- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. 
