### PR TITLE
Simplify downgrade CI on Julia 1.12

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -42,7 +42,7 @@ jobs:
           mode: 'forcedeps'
           julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Run tests on the locked dependency graph
+      - name: Run tests without re-resolving
         env:
           JULIA_LOAD_PATH: "${{ github.workspace }}/test:${{ github.workspace }}:@stdlib"
-        run: julia --project=test --startup-file=no --color=yes -e 'include("test/runtests.jl")'
+        run: julia --color=yes --check-bounds=yes --project=test test/runtests.jl

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -42,6 +42,8 @@ jobs:
           mode: 'forcedeps'
           julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Instantiate the locked test environment
+        run: julia --color=yes --project=test -e 'import Pkg; Pkg.instantiate()'
       - name: Run tests without re-resolving
         env:
           JULIA_LOAD_PATH: "${{ github.workspace }}/test:${{ github.workspace }}:@stdlib"

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -46,4 +46,3 @@ jobs:
         with:
           allow_reresolve: false
           force_latest_compatible_version: false
-          test_args: general

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: 'min'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
@@ -40,9 +40,9 @@ jobs:
         with:
           projects: '.,test'
           mode: 'forcedeps'
-          julia_version: '1.12'
+          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: false
-          force_latest_compatible_version: false
+      - name: Run tests on the locked dependency graph
+        env:
+          JULIA_LOAD_PATH: "${{ github.workspace }}/test:${{ github.workspace }}:@stdlib"
+        run: julia --project=test --startup-file=no --color=yes -e 'include("test/runtests.jl")'

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -22,29 +22,16 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: 'min'
+          version: '1.12'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
-      - name: Limit workspace to the test project
-        run: |
-          julia --color=yes -e '
-            using TOML
-            project = TOML.parsefile("Project.toml")
-            project["workspace"]["projects"] = ["test"]
-            open("Project.toml", "w") do io
-              TOML.print(io, project)
-            end
-          '
       - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
           projects: '.,test'
           mode: 'forcedeps'
-          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Instantiate the locked test environment
-        run: julia --color=yes --project=test -e 'import Pkg; Pkg.instantiate()'
-      - name: Run tests without re-resolving
-        env:
-          JULIA_LOAD_PATH: "${{ github.workspace }}/test:${{ github.workspace }}:@stdlib"
-        run: julia --color=yes --check-bounds=yes --project=test test/runtests.jl
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: false
+          force_latest_compatible_version: false

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -8,26 +8,42 @@ on:
     branches: [master, main]
     paths-ignore:
       - 'docs/**'
-env:
-  PYTHON: ~
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ['1.9']
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML,InteractiveUtils,Random,LinearAlgebra,Dates
-          julia_version: ${{ matrix.version }}
+          version: '1.12'
       - uses: julia-actions/cache@v3
+        with:
+          delete-old-caches: false
+      - name: Limit workspace to the test project
+        run: |
+          julia --color=yes -e '
+            using TOML
+            project = TOML.parsefile("Project.toml")
+            project["workspace"]["projects"] = ["test"]
+            open("Project.toml", "w") do io
+              TOML.print(io, project)
+            end
+          '
+      - uses: julia-actions/julia-downgrade-compat@v2.7.0
+        with:
+          projects: '.,test'
+          mode: 'forcedeps'
+          julia_version: '1.12'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
           allow_reresolve: false
           force_latest_compatible_version: false
+          test_args: general


### PR DESCRIPTION
## Summary
- run lower-bound resolution and testing on Julia 1.12
- resolve root and split test environments together, then build and test the locked graph
- disable both `Pkg.test` re-resolution paths
- remove pre-1.12 setup, manifest-repair, workspace-rewrite, and direct-test workarounds
- retain strict `forcedeps` verification and only the required stdlib exclusions

No compat bounds are added to `test/Project.toml`.

## Validation
- `actionlint`
- all Project TOML files parsed with Julia 1.12
- aggregate workflow-contract and stdlib-skip checks
- targeted locked-manifest runs on representative and exceptional repositories
- two independent cross-repository reviews

Existing package lower-bound failures are intentionally left visible for separate follow-up.