### PR TITLE
Skip quality tools in downgrade tests

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+env:
+  QUANTUMSAVORY_DOWNGRADE_TEST: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ testfilter = ti -> begin
   else
     push!(exclude, :jet)
   end
-  if !(VERSION >= v"1.10")
+  if !(VERSION >= v"1.10") || get(ENV, "QUANTUMSAVORY_DOWNGRADE_TEST", "") == "true"
     push!(exclude, :doctests)
     push!(exclude, :aqua)
   end


### PR DESCRIPTION
## Summary

- set the shared QUANTUMSAVORY_DOWNGRADE_TEST flag in downgrade CI
- exclude applicable Aqua and doctest checks only from the minimum-dependency run
- preserve ordinary tests and the existing dedicated or opt-in JET path
- leave the shared downgrade action inputs unchanged

## Validation

- parsed the changed Julia test entry point
- parsed the workflow YAML
- ran git diff --check
- hosted CI provides the locked minimum-version integration test